### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+SerializableSession*.iml
+.idea
+out


### PR DESCRIPTION
Hi,

Thanks for the plugin - it is a great idea. I've started to use it and made a few miscellaneous improvements to enhance its usefulness:
- It now keeps a list of attributes that failed to be serialized, then logs all of them as an error. This helps highlight any object that is unserializable, not just the first one.
- It can be configured not to throw an exception anymore and only logs a error. Simply set the `serializableSessions.throwExceptionOnFailure` to false (defaults to true).
- Changing the classLoader to be getClass().classLoader - the findChild() way was failing for me
- Adjusting log messages...

Let me know if you have any concerns or questions about the changes - especially the findChild() one.

Thanks again,

Adam
