### PR TITLE
QA -  Prevent error “No such property: container for class: org.apache.c...

### DIFF
--- a/src/groovy/com/dawsonsystems/session/SessionTrackerValve.groovy
+++ b/src/groovy/com/dawsonsystems/session/SessionTrackerValve.groovy
@@ -9,7 +9,7 @@ import org.apache.catalina.valves.ValveBase
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.apache.catalina.util.CustomObjectInputStream
-import static org.codehaus.groovy.grails.commons.ConfigurationHolder.getConfig
+import static grails.util.Holders.config
 
 public class SessionTrackerValve extends ValveBase {
   private static Logger log = LoggerFactory.getLogger(SessionTrackerValve);

--- a/src/groovy/com/dawsonsystems/session/SessionTrackerValve.groovy
+++ b/src/groovy/com/dawsonsystems/session/SessionTrackerValve.groovy
@@ -9,7 +9,6 @@ import org.apache.catalina.valves.ValveBase
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.apache.catalina.util.CustomObjectInputStream
-import org.apache.catalina.session.StandardManager
 import static org.codehaus.groovy.grails.commons.ConfigurationHolder.getConfig
 
 public class SessionTrackerValve extends ValveBase {
@@ -127,9 +126,6 @@ public class SessionTrackerValve extends ValveBase {
   }
 
   void deSerialize(byte[] bytes) {
-
-    def manager = new StandardManager()
-    manager.container = tomcat.connector.container
 
     def bis = new ByteArrayInputStream(bytes)
 


### PR DESCRIPTION
Hi,
This plugin is very useful for us to prevent session`s lost in production. I have changed some things to have the log more clean in development

I was having repetitive error in log with the plugin, the Manager was not used anywhere and causing this log error. I have deleted it. Also, I have change the future deprecated ConfigurationHolder

Let me know if you are agree or not with the changes

Thanks,

Best Regards

-05-09 11:43:13,706 [http-bio-8443-exec-2] ERROR session.SessionTrackerValve  - An unexpected error occured while attempting to deserialize the session : No such property: container for class: org.apache.catalina.connector.Connector
Message: No such property: container for class: org.apache.catalina.connector.Connector
    Line | Method
->>  132 | deSerialize  in com.dawsonsystems.session.SessionTrackerValve

---

|     79 | storeSession in     ''
|     29 | invoke . . . in     ''
|   1145 | runWorker    in java.util.concurrent.ThreadPoolExecutor
|    615 | run . . . .  in java.util.concurrent.ThreadPoolExecutor$Worker
^    744 | run          in java.lang.Thread
